### PR TITLE
Fix CLI name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,19 @@ WriteCommit
 
 ```bash
 # Preview message without committing
-write-commit --dry-run
+WriteCommit --dry-run
 
 # Detailed output for debugging
-write-commit --verbose
+WriteCommit --verbose
 
 # Custom AI parameters
-write-commit --temperature 0.7 --topp 0.9 --pattern custom_pattern
+WriteCommit --temperature 0.7 --topp 0.9 --pattern custom_pattern
 
 # Force reinstall all patterns
-write-commit --reinstall-patterns
+WriteCommit --reinstall-patterns
 
 # Combine multiple options
-write-commit --dry-run --verbose --temperature 0.5 --reinstall-patterns
+WriteCommit --dry-run --verbose --temperature 0.5 --reinstall-patterns
 ```
 
 ## ⚙️ Configuration Options
@@ -122,7 +122,7 @@ write-commit --dry-run --verbose --temperature 0.5 --reinstall-patterns
 
 ```bash
 # Run the setup wizard
-write-commit --setup
+WriteCommit --setup
 ```
 
 This will prompt you to enter your API key and securely save it to `~/.writecommit/config.json`.

--- a/demo.ps1
+++ b/demo.ps1
@@ -7,7 +7,7 @@ Write-Host ""
 
 Write-Host "1. Checking tool installation..." -ForegroundColor Yellow
 try {
-    $version = write-commit --version 2>$null
+    $version = WriteCommit --version 2>$null
     if ($LASTEXITCODE -eq 0) {
         Write-Host "✅ WriteCommit is installed" -ForegroundColor Green
     } else {
@@ -21,7 +21,7 @@ try {
 
 Write-Host ""
 Write-Host "2. Showing help..." -ForegroundColor Yellow
-write-commit --help
+WriteCommit --help
 
 Write-Host ""
 Write-Host "3. Checking git repository status..." -ForegroundColor Yellow
@@ -40,14 +40,14 @@ if ($LASTEXITCODE -ne 0) {
         Write-Host "4. Running WriteCommit in dry-run mode..." -ForegroundColor Yellow
         Write-Host "   (This will generate a commit message without committing)" -ForegroundColor Gray
         Write-Host ""
-        write-commit --dry-run --verbose
+        WriteCommit --dry-run --verbose
         
     } else {
         Write-Host "ℹ️ No staged changes found" -ForegroundColor Blue
         Write-Host "   To test the tool:" -ForegroundColor Gray
         Write-Host "   1. Make some changes to files" -ForegroundColor Gray
         Write-Host "   2. Run: git add ." -ForegroundColor Gray
-        Write-Host "   3. Run: write-commit --dry-run" -ForegroundColor Gray
+        Write-Host "   3. Run: WriteCommit --dry-run" -ForegroundColor Gray
     }
 }
 


### PR DESCRIPTION
## Summary
- update README examples to use `WriteCommit`
- update PowerShell demo script to call `WriteCommit`

## Testing
- `dotnet restore Write-Commit.sln`
- `dotnet build Write-Commit.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68603ade2124832aa4aeefdf493c52f1