### PR TITLE
Fix installation scripts for new repo location

### DIFF
--- a/install-universal.sh
+++ b/install-universal.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # Universal web installer for WriteCommit tool
-# Usage: curl -sSL https://raw.githubusercontent.com/PatrickRuddiman/Toolkit/main/Tools/Write-Commit/install-universal.sh | bash
-# Or with arch override: curl -sSL https://raw.githubusercontent.com/PatrickRuddiman/Toolkit/main/Tools/Write-Commit/install-universal.sh | bash -s -- --arch linux-arm64
+# Usage: curl -sSL https://raw.githubusercontent.com/PatrickRuddiman/WriteCommit/main/install-universal.sh | bash
+# Or with arch override: curl -sSL https://raw.githubusercontent.com/PatrickRuddiman/WriteCommit/main/install-universal.sh | bash -s -- --arch linux-arm64
 
 set -e
 
 # Configuration
-REPO="PatrickRuddiman/Toolkit"
-TOOL_NAME="WriteCommit"
+REPO="PatrickRuddiman/WriteCommit"
+# Binary name inside the archive
+BINARY_NAME="WriteCommit"
+# Asset prefix is lowercase
+TOOL_ASSET="writecommit"
 INSTALL_DIR="$HOME/.local/bin"
 
 # Parse command line arguments
@@ -70,7 +73,7 @@ else
         *)
             echo "❌ Unsupported OS: $OS"
             echo "This script is for Linux and macOS only. For Windows, use:"
-            echo "iex (irm https://raw.githubusercontent.com/PatrickRuddiman/Toolkit/main/Tools/Write-Commit/install-web.ps1)"
+            echo "iex (irm https://raw.githubusercontent.com/PatrickRuddiman/WriteCommit/main/install-web.ps1)"
             exit 1
             ;;
     esac
@@ -91,13 +94,17 @@ fi
 echo "📦 Latest version: $VERSION"
 
 # Construct download URL
-ASSET_NAME="${TOOL_NAME}-${VERSION}-${RUNTIME}.tar.gz"
+ASSET_NAME="${TOOL_ASSET}-${RUNTIME}-${VERSION}.tar.gz"
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET_NAME"
 
 echo "⬇️  Downloading $ASSET_NAME..."
 
-# Create temporary directory
+# Create temporary directory and ensure cleanup
 TEMP_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
 cd "$TEMP_DIR"
 
 # Download the release
@@ -121,15 +128,15 @@ if [ ! -d "$INSTALL_DIR" ]; then
 fi
 
 # Install the binary
-echo "📥 Installing $TOOL_NAME to $INSTALL_DIR..."
-cp "$TOOL_NAME" "$INSTALL_DIR/"
-chmod +x "$INSTALL_DIR/$TOOL_NAME"
+echo "📥 Installing $BINARY_NAME to $INSTALL_DIR..."
+cp "$BINARY_NAME" "$INSTALL_DIR/"
+chmod +x "$INSTALL_DIR/$BINARY_NAME"
 
 # Cleanup
 cd - > /dev/null
 rm -rf "$TEMP_DIR"
 
-echo "✅ $TOOL_NAME $VERSION ($RUNTIME) installed successfully!"
+echo "✅ $BINARY_NAME $VERSION ($RUNTIME) installed successfully!"
 echo ""
 echo "📝 Note: Make sure $INSTALL_DIR is in your PATH."
 echo "   Add this line to your ~/.bashrc or ~/.zshrc:"
@@ -137,16 +144,16 @@ echo "   export PATH=\"$INSTALL_DIR:\$PATH\""
 echo ""
 echo "🚀 Example usage:"
 echo "   git add ."
-echo "   $TOOL_NAME"
-echo "   $TOOL_NAME --dry-run"
-echo "   $TOOL_NAME --verbose"
+echo "   $BINARY_NAME"
+echo "   $BINARY_NAME --dry-run"
+echo "   $BINARY_NAME --verbose"
 
 # Check if binary is in PATH
-if command -v "$TOOL_NAME" >/dev/null 2>&1; then
+if command -v "$BINARY_NAME" >/dev/null 2>&1; then
     echo ""
-    echo "🎉 $TOOL_NAME is ready to use!"
+    echo "🎉 $BINARY_NAME is ready to use!"
 else
     echo ""
-    echo "⚠️  $TOOL_NAME is not in your PATH. Restart your shell or run:"
+    echo "⚠️  $BINARY_NAME is not in your PATH. Restart your shell or run:"
     echo "   export PATH=\"$INSTALL_DIR:\$PATH\""
 fi

--- a/install-web.ps1
+++ b/install-web.ps1
@@ -1,5 +1,5 @@
 # Web installer for WriteCommit tool (Windows)
-# Usage: iex (irm https://raw.githubusercontent.com/PatrickRuddiman/Toolkit/main/Tools/Write-Commit/install-web.ps1)
+# Usage: iex (irm https://raw.githubusercontent.com/PatrickRuddiman/WriteCommit/main/install-web.ps1)
 
 param(
      [string]$InstallDir = "$env:LOCALAPPDATA\Programs\WriteCommit",
@@ -9,7 +9,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Configuration
-$Repo = "PatrickRuddiman/Toolkit"
+$Repo = "PatrickRuddiman/WriteCommit"
 $ToolName = "writecommit"
 $Platform = "windows"
 $Arch = "x64"

--- a/install-web.sh
+++ b/install-web.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 # Web installer for WriteCommit tool (Linux/macOS)
-# Usage: curl -sSL https://raw.githubusercontent.com/PatrickRuddiman/Toolkit/main/Tools/Write-Commit/install-web.sh | bash
+# Usage: curl -sSL https://raw.githubusercontent.com/PatrickRuddiman/WriteCommit/main/install-web.sh | bash
 
 set -e
 
 # Configuration
-REPO="PatrickRuddiman/Toolkit"
-TOOL_NAME="WriteCommit"
+REPO="PatrickRuddiman/WriteCommit"
+# Name of the binary within the archive
+BINARY_NAME="WriteCommit"
+# Prefix for assets
+TOOL_ASSET="writecommit"
 INSTALL_DIR="$HOME/.local/share/WriteCommit"
 BIN_DIR="$HOME/.local/bin"
 VERSION="latest"
@@ -44,7 +47,7 @@ case $OS in
     *)
         echo "❌ Unsupported OS: $OS"
         echo "This script is for Linux and macOS only. For Windows, use the PowerShell installer:"
-        echo "iex (irm https://raw.githubusercontent.com/PatrickRuddiman/Toolkit/main/Tools/Write-Commit/install-web.ps1)"
+        echo "iex (irm https://raw.githubusercontent.com/PatrickRuddiman/WriteCommit/main/install-web.ps1)"
         exit 1
         ;;
 esac
@@ -81,13 +84,17 @@ fi
 echo "📦 Version: $VERSION"
 
 # Construct download URL with correct naming pattern
-ASSET_NAME="${TOOL_NAME}-${PLATFORM}-${ARCH_TAG}-${VERSION}.tar.gz"
+ASSET_NAME="${TOOL_ASSET}-${PLATFORM}-${ARCH_TAG}-${VERSION}.tar.gz"
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET_NAME"
 
 echo "⬇️  Downloading $ASSET_NAME from $DOWNLOAD_URL..."
 
-# Create temporary directory
+# Create temporary directory and ensure cleanup
 TEMP_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
 cd "$TEMP_DIR"
 
 # Download the release
@@ -120,10 +127,10 @@ fi
 
 # Create a wrapper script in the bin directory
 echo "📥 Creating wrapper script in $BIN_DIR..."
-WRAPPER_PATH="$BIN_DIR/$TOOL_NAME"
+WRAPPER_PATH="$BIN_DIR/$BINARY_NAME"
 cat > "$WRAPPER_PATH" << EOF
 #!/bin/bash
-exec "$INSTALL_DIR/$TOOL_NAME" "\$@"
+exec "$INSTALL_DIR/$BINARY_NAME" "\$@"
 EOF
 chmod +x "$WRAPPER_PATH"
 
@@ -138,9 +145,11 @@ update_shell_config() {
     
     if [ -f "$config_file" ]; then
         if ! grep -q "$BIN_DIR" "$config_file"; then
-            echo "" >> "$config_file"
-            echo "# Added by WriteCommit installer" >> "$config_file"
-            echo "$path_entry" >> "$config_file"
+            {
+                echo ""
+                echo "# Added by WriteCommit installer"
+                echo "$path_entry"
+            } >> "$config_file"
             echo "✅ Updated $config_file"
             return 0
         else
@@ -170,9 +179,11 @@ if command -v fish >/dev/null 2>&1 || [ "$SHELL" = "/usr/bin/fish" ]; then
     if [ -f "$FISH_CONFIG" ]; then
         if ! grep -q "$BIN_DIR" "$FISH_CONFIG"; then
             mkdir -p "$(dirname "$FISH_CONFIG")"
-            echo "" >> "$FISH_CONFIG"
-            echo "# Added by WriteCommit installer" >> "$FISH_CONFIG"
-            echo "fish_add_path $BIN_DIR" >> "$FISH_CONFIG"
+            {
+                echo ""
+                echo "# Added by WriteCommit installer"
+                echo "fish_add_path $BIN_DIR"
+            } >> "$FISH_CONFIG"
             echo "✅ Updated $FISH_CONFIG"
             PATH_UPDATED=true
         else
@@ -188,21 +199,21 @@ if [ "$PATH_UPDATED" = false ]; then
 fi
 
 echo ""
-echo "✅ WriteCommit $VERSION installed successfully!"
+echo "✅ $BINARY_NAME $VERSION installed successfully!"
 echo ""
 echo "📂 Installation directory: $INSTALL_DIR"
 echo "🚀 Example usage:"
 echo "   git add ."
-echo "   WriteCommit"
-echo "   WriteCommit --dry-run"
-echo "   WriteCommit --verbose"
+echo "   $BINARY_NAME"
+echo "   $BINARY_NAME --dry-run"
+echo "   $BINARY_NAME --verbose"
 
 # Check if binary is in PATH
-if command -v WriteCommit >/dev/null 2>&1; then
+if command -v "$BINARY_NAME" >/dev/null 2>&1; then
     echo ""
-    echo "🎉 WriteCommit is ready to use!"
+    echo "🎉 $BINARY_NAME is ready to use!"
 else
     echo ""
-    echo "⚠️ You need to restart your terminal or run the following command to use WriteCommit in this session:"
+    echo "⚠️ You need to restart your terminal or run the following command to use $BINARY_NAME in this session:"
     echo "   export PATH=\"$BIN_DIR:\$PATH\""
 fi

--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,7 @@ runtime="linux-x64"
 exeName="WriteCommit"
 
 echo "Publishing WriteCommit for $runtime..."
-dotnet publish WriteCommit.csproj --configuration Release --runtime $runtime --self-contained true --output "publish/$runtime"
-
-if [ $? -eq 0 ]; then
+if dotnet publish WriteCommit.csproj --configuration Release --runtime "$runtime" --self-contained true --output "publish/$runtime"; then
     echo "Publish successful!"
     
     # Create a directory in user's local bin if it doesn't exist
@@ -23,10 +21,7 @@ if [ $? -eq 0 ]; then
     targetPath="$localBin/$exeName"
     
     echo "Installing WriteCommit to $targetPath..."
-    cp "$sourcePath" "$targetPath"
-    chmod +x "$targetPath"
-    
-    if [ $? -eq 0 ]; then
+    if cp "$sourcePath" "$targetPath" && chmod +x "$targetPath"; then
         echo "✅ WriteCommit installed successfully!"
         
         echo "Note: Make sure $localBin is in your PATH."


### PR DESCRIPTION
## Summary
- update repo URLs in installation scripts
- adjust asset naming to match release artifacts
- fix unsupported OS message
- clean up path updates and wrapper generation
- add cleanup traps for temporary directories
- fix style issues in `install.sh`

## Testing
- `shellcheck install-universal.sh install-web.sh install.sh`
- `bash -n install-universal.sh install-web.sh install.sh`
- `pwsh -NoLogo -NoProfile -Command "Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -Path install-web.ps1 -Severity Error"`
- `pwsh -NoLogo -NoProfile -Command "Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -Path install.ps1 -Severity Error"`
- `dotnet build Write-Commit.sln`
- `bash install-web.sh --version v0.1.3 --install-dir /tmp/writecommit_test`
- `bash install-universal.sh --arch linux-x64`


------
https://chatgpt.com/codex/tasks/task_e_6860609831e0832a852f628b84f38cc9