### PR TITLE
Enable single-file publishing

### DIFF
--- a/WriteCommit.csproj
+++ b/WriteCommit.csproj
@@ -17,6 +17,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>git;commit;ai;openai;cli;tool</PackageTags>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <RuntimeIdentifiers>linux-x64;linux-arm64;osx-x64;osx-arm64;win-x64</RuntimeIdentifiers>
+    <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- package content in a single executable with .NET's PublishSingleFile
- ensure patterns directory is included in single-file bundle

## Testing
- `dotnet build WriteCommit.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6862da3e3bf4832a95c30bc037ec8e37